### PR TITLE
Issue 18 add help flag

### DIFF
--- a/src/Hi/Option.hs
+++ b/src/Hi/Option.hs
@@ -4,6 +4,7 @@ module Hi.Option
     (
       getInitFlags
     , getMode
+    , usage
     ) where
 
 import           Hi.Config             (parseConfig)
@@ -31,6 +32,7 @@ options =
     , Option ['r'] ["repository"]         (ReqArg (Val "repository" ) "REPOSITORY"  ) "Template repository    ( optional ) "
     , Option []    ["configuration-file"] (ReqArg (Val "configFile" ) "CONFIGFILE"  ) "Run with configuration file"
     , Option ['v'] ["version"]            (NoArg  Version)                            "Show version number"
+    , Option ['h'] ["help"]               (NoArg  Help)                               "Display this help and exit"
     ]
 
 -- | Returns 'InitFlags'.
@@ -74,7 +76,11 @@ readFileMaybe f = do
 getMode :: IO Mode
 getMode = do
     args <- parseArgs <$> getArgs
-    return $ if Version `elem` args then ShowVersion else Run
+    return $ modeFor args
+  where
+    modeFor args | Help `elem` args    = ShowHelp
+                 | Version `elem` args = ShowVersion
+                 | otherwise           = Run
 
 parseArgs :: [String] -> [Arg]
 parseArgs argv =

--- a/src/Hi/Types.hs
+++ b/src/Hi/Types.hs
@@ -22,7 +22,7 @@ type Error = String
 type Label = String
 
 -- | Arguments.
-data Arg = Version | Val Label String deriving(Eq, Show)
+data Arg = Version | Help | Val Label String deriving(Eq, Show)
 
 -- | Run mode.
-data Mode = ShowVersion | Run deriving(Eq, Show)
+data Mode = ShowVersion | ShowHelp | Run deriving(Eq, Show)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import           Hi         (run)
-import           Hi.Option  (getInitFlags, getMode)
+import           Hi.Option  (getInitFlags, getMode, usage)
 import           Hi.Types
 import           Hi.Version (version)
 
@@ -9,5 +9,6 @@ main :: IO ()
 main = do
     mode <- getMode
     case mode of
+      ShowHelp -> putStrLn usage
       ShowVersion -> putStrLn version
       _           -> run =<< getInitFlags


### PR DESCRIPTION
Add a --help flag to the command line.

This prevents the error `hi: unrecognized option '--help'`.

This is for issue https://github.com/fujimura/hi/issues/18.  It is based off of the code for pull request https://github.com/fujimura/hi/pull/20 so pull request https://github.com/fujimura/hi/pull/20 should be merged before this is merged. 
