### PR TITLE
Add $directoryName replacement option.

### DIFF
--- a/src/Hi/FilePath.hs
+++ b/src/Hi/FilePath.hs
@@ -14,10 +14,11 @@ import           System.FilePath (joinPath)
 -- | Convert given path to the destination path, with given options.
 rewritePath :: InitFlags -> FilePath -> FilePath
 rewritePath flags =
-    rename1 . rename2 . untemplate
+    rename1 . rename2 . rename3 . untemplate
   where
     rename1 = replace "package-name" $ fromJust $ lookup "packageName" flags
-    rename2 = replace "ModuleName" (toDir . fromJust $ lookup "moduleName" flags)
+    rename2 = replace "directory-name" $ fromJust $ lookup "directoryName" flags
+    rename3 = replace "ModuleName" (toDir . fromJust $ lookup "moduleName" flags)
 
 -- | Convert module name to path
 -- @

--- a/src/Hi/Flag.hs
+++ b/src/Hi/Flag.hs
@@ -21,6 +21,7 @@ extractInitFlags args = validateAll [(l, v) | (Val l v) <- args]
                   , hasKey "moduleName"
                   , hasKey "author"
                   , hasKey "email"
+                  , hasKey "directoryName"
                   , hasKey "repository"
                   , hasKey "year"
                   ]

--- a/src/Hi/Option.hs
+++ b/src/Hi/Option.hs
@@ -25,20 +25,22 @@ import           System.FilePath       (joinPath)
 -- | Available options.
 options :: [OptDescr Arg]
 options =
-    [ Option ['p'] ["package-name"]       (ReqArg (Val "packageName") "package-name") "Name of package"
-    , Option ['m'] ["module-name"]        (ReqArg (Val "moduleName" ) "Module.Name" ) "Name of Module"
-    , Option ['a'] ["author"]             (ReqArg (Val "author"     ) "NAME"        ) "Name of the project's author"
-    , Option ['e'] ["email"]              (ReqArg (Val "email"      ) "EMAIL"       ) "Email address of the maintainer"
-    , Option ['r'] ["repository"]         (ReqArg (Val "repository" ) "REPOSITORY"  ) "Template repository    ( optional ) "
-    , Option []    ["configuration-file"] (ReqArg (Val "configFile" ) "CONFIGFILE"  ) "Run with configuration file"
-    , Option ['v'] ["version"]            (NoArg  Version)                            "Show version number"
-    , Option ['h'] ["help"]               (NoArg  Help)                               "Display this help and exit"
+    [ Option ['p'] ["package-name"]       (ReqArg (Val "packageName"   ) "package-name"   ) "Name of package"
+    , Option ['m'] ["module-name"]        (ReqArg (Val "moduleName"    ) "Module.Name"    ) "Name of Module"
+    , Option ['a'] ["author"]             (ReqArg (Val "author"        ) "NAME"           ) "Name of the project's author"
+    , Option ['e'] ["email"]              (ReqArg (Val "email"         ) "EMAIL"          ) "Email address of the maintainer"
+    , Option ['d'] ["directory-name"]     (ReqArg (Val "directoryName" ) "directoryname"  ) "Top-level directory name ( optional ) "
+    , Option ['r'] ["repository"]         (ReqArg (Val "repository"    ) "REPOSITORY"     ) "Template repository      ( optional ) "
+    , Option []    ["configuration-file"] (ReqArg (Val "configFile"    ) "CONFIGFILE"     ) "Run with configuration file"
+    , Option ['v'] ["version"]            (NoArg  Version)                                  "Show version number"
+    , Option ['h'] ["help"]               (NoArg  Help)                                     "Display this help and exit"
     ]
 
 -- | Returns 'InitFlags'.
 getInitFlags :: IO InitFlags
 getInitFlags = handleError
                <$> extractInitFlags
+               =<< (return . addDefaultDirectoryName)
                =<< addDefaultRepo
                =<< addArgsFromConfigFile
                =<< addYear
@@ -59,6 +61,12 @@ getInitFlags = handleError
 
     addDefaultRepo :: [Arg] -> IO [Arg]
     addDefaultRepo vals = return $ vals ++ [Val "repository" defaultRepo]
+
+    addDefaultDirectoryName :: [Arg] -> [Arg]
+    addDefaultDirectoryName [] = []
+    addDefaultDirectoryName vals@((Val "packageName" packageName):_) =
+        vals ++ [Val "directoryName" packageName]
+    addDefaultDirectoryName (v:vals) = v : addDefaultDirectoryName vals
 
     handleError :: Either [String] InitFlags -> IO InitFlags
     handleError result = case result of


### PR DESCRIPTION
Added the option --directory-name. It is intended to let you set a
different directory name than the package name. So, for instance, your
top-level directory could get created with the name "foo", even though
your package name is "bar-baz".

--directory-name defaults to being the same as --package-name if not
specified explicity.

This will give you the file name/directory name replacement string
"directory-name" (just like "package-name").

It also gives a templating parameter $directoryName.  It could be used
inside templates, although it is not intended to be used inside
templates.

This is the pull-request for issue https://github.com/fujimura/hi/issues/17.
