### PR TITLE
Only convert template files to text to allow non-textual files to be included in a template repo

### DIFF
--- a/hi.cabal
+++ b/hi.cabal
@@ -66,16 +66,16 @@ library
   hs-source-dirs:
       src
   build-depends:
-        base       == 4.*
+        base          == 4.*
       , bytestring
       , directory
       , filepath
       , parsec
       , process
       , split
-      , template   == 0.2.*
-      , temporary  >= 1.2.0.3
-      , text       > 1.0
+      , template      == 0.2.*
+      , temporary-rc  >= 1.2.0.3
+      , text          > 1.0
       , time
 
 executable hi

--- a/src/Hi/Git.hs
+++ b/src/Hi/Git.hs
@@ -5,9 +5,6 @@ module Hi.Git
     , expandUrl
     ) where
 
-import           Hi.Types
-import           Hi.Utils
-
 import           Control.Applicative
 import           Data.List           (isPrefixOf)
 import           System.Exit         (ExitCode)

--- a/src/Hi/Template.hs
+++ b/src/Hi/Template.hs
@@ -1,6 +1,7 @@
 module Hi.Template
     (
-      readTemplates
+      isTemplate
+    , readTemplates
     , untemplate
     ) where
 
@@ -8,6 +9,10 @@ import           Hi.Directory        (inTemporaryDirectory)
 import qualified Hi.Git              as Git
 import           Hi.Types
 
+import           Control.Applicative ((<$>))
+
+import qualified Data.ByteString     as BS (readFile)
+import           Data.List           (isSuffixOf)
 import           Data.List.Split     (splitOn)
 
 -- | Read templates in given 'FilePath'
@@ -17,8 +22,19 @@ readTemplates repo =
         -- TODO Handle error
         _ <- Git.clone $ Git.expandUrl repo
         paths <- Git.lsFiles
-        contents <- mapM readFile paths
-        return $ zip paths contents
+        mapM fetchFile paths
+
+fetchFile :: FilePath -> IO File
+fetchFile fp | isTemplate fp = TemplateFile fp <$> BS.readFile fp
+             | otherwise     = RegularFile  fp <$> BS.readFile fp
+
+-- | Determine if a given filepath is a template file based on its extension
+-- >>> isTemplate "Example.hs.template"
+-- True
+-- >>> isTemplate "NotATemplate.hs"
+-- False
+isTemplate :: FilePath -> Bool
+isTemplate = isSuffixOf ".template"
 
 -- | Remove \".template\" from 'FilePath'
 untemplate :: FilePath -> FilePath

--- a/src/Hi/Types.hs
+++ b/src/Hi/Types.hs
@@ -4,11 +4,16 @@ module Hi.Types
     ( Label
     , Option(..)
     , Mode(..)
+    , File(..)
     , Files
     , Error
     ) where
 
-type Files = [(FilePath, String)]
+import Data.ByteString (ByteString)
+
+data File = TemplateFile { getFilePath :: FilePath, getFileContents :: ByteString } | RegularFile { getFilePath :: FilePath, getFileContents :: ByteString }
+
+type Files = [File]
 
 type Error = String
 

--- a/test/FeatureSpec.hs
+++ b/test/FeatureSpec.hs
@@ -186,3 +186,5 @@ testDirectory = "test_project"
 
 quote :: String -> String
 quote s = "\"" ++ s ++ "\""
+
+{-# ANN module "HLint: Redundant do" #-}

--- a/test/Hi/GitSpec.hs
+++ b/test/Hi/GitSpec.hs
@@ -1,7 +1,5 @@
 module Hi.GitSpec ( spec ) where
 
-import           Hi.Types
-import           Hi.Utils
 import           Hi.Git
 
 import           Test.Hspec


### PR DESCRIPTION
I was getting errors about illegal byte sequences when trying clone a template.

This commit separates template files and regular files, storing their contents as ByteStrings, and only converts the template files to Text for templating.

TemplateFile and RegularFile are exactly the same save the constructor name used as a flag. There's probably a better way to do this, but this seemed like the quickest route.
