### PR TITLE
Bump the version on hackage.

### DIFF
--- a/hi.cabal
+++ b/hi.cabal
@@ -5,7 +5,7 @@
 -- hash: 34cffe672cc33cc797765e9759adfaf551776d336457e9f942291467d0b6d90d
 
 name:           hi
-version:        1.2.0.1
+version:        1.2.0.2
 cabal-version:  >= 1.10
 build-type:     Simple
 license:        BSD3


### PR DESCRIPTION
Since it was last tagged 1.2.0.1, this package has not had any breaking changes.
It has had one important fix (#60), but this has not been pushed to hackage.

As a consequence hi, does not build on hackage (and also on NixOS) and `cabal
install` fails.

This change adds a new minor version which includes the fix in #60.