### PR TITLE
Fix tests for new environments

### DIFF
--- a/hi.cabal
+++ b/hi.cabal
@@ -149,7 +149,6 @@ test-suite doctests
         FeatureSpec
         Hi.GitSpec
         HiSpec
-        Spec
         SpecHelper
         Paths_hi
     default-language: Haskell2010

--- a/hi.cabal
+++ b/hi.cabal
@@ -132,6 +132,7 @@ test-suite doctests
         process,
         split,
         template ==0.2.*,
+        temporary >=1.2.0.3,
         text >1.0,
         time
     other-modules:
@@ -146,10 +147,6 @@ test-suite doctests
         Hi.Template
         Hi.Types
         Main
-        FeatureSpec
-        Hi.GitSpec
-        HiSpec
-        SpecHelper
         Paths_hi
     default-language: Haskell2010
     type: exitcode-stdio-1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,8 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.9
+## resolver: lts-8.9
+resolver: lts-12.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +40,8 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- template-0.2.0.10
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,8 @@
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
 ## resolver: lts-8.9
-resolver: lts-12.26
+## resolver: lts-12.26
+resolver: lts-14.7
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
I fixed package meta-data (hi.cabal and stack.yaml) to fix tests for new environments. I tested with stackage lts-12.26 and lts-14.7.

The diff is:

- stack.yaml: Upgrade the resolver.
- stack.yaml: Add "template" package to "extra-deps", because "template" package has been removed from stackage.
- hi.cabal doctests: Add "temporary" package to "build-depends" to fix build error.
- hi.cabal doctests: Remove modules about hspec from "other-modules" to fix build error. They are not necessary.

I'm not sure how to fix package.yaml, but probably we should fix it to match the change in hi.cabal.
